### PR TITLE
fix(niova-ctl): nisd port allocation issue

### DIFF
--- a/controlplane/niova-ctl/types.go
+++ b/controlplane/niova-ctl/types.go
@@ -377,13 +377,13 @@ func (c *Config) AllocatePortPair(hypervisorUUID string, portRange string, cpCli
 	if cpClient != nil {
 		// Type assert to get the actual client interface
 		if client, ok := cpClient.(interface {
-			GetNisdCfg(req ctlplfl.GetReq) ([]ctlplfl.Nisd, error)
+			GetNisds(req ctlplfl.GetReq) ([]ctlplfl.Nisd, error)
 		}); ok {
 			// Create a request to get all NISDs
 			// Get all NISDs and filter by hypervisor UUID locally
-			req := ctlplfl.GetReq{ID: ""} // Empty ID to get all NISDs
+			req := ctlplfl.GetReq{GetAll: true} // Empty ID to get all NISDs
 
-			nisds, err := client.GetNisdCfg(req)
+			nisds, err := client.GetNisds(req)
 			if err == nil {
 				// Process the NISDs to extract allocated ports for this hypervisor
 				for _, nisd := range nisds {


### PR DESCRIPTION
- Fetch NISD info method was renamed from GetNisdCfgs -> GetNisds and changes for this, were not made in the port allocation method as a result, it was unable to fetch nisd info and was allocating same port to all the nisds.
- To fix the issue made changes to call the GetNisds method.
- Pending: Add an additional validation step to not allocate ports, when we fail to query NISD details