### PR TITLE
fix(CP): fix vdev distribution

### DIFF
--- a/controlplane/ctlplanefuncs/client/vdev_entity_filter_test.go
+++ b/controlplane/ctlplanefuncs/client/vdev_entity_filter_test.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/google/uuid"
 
 	cpLib "github.com/00pauln00/niova-mdsvc/controlplane/ctlplanefuncs/lib"
 )
@@ -383,4 +384,99 @@ func TestCreateVdevWithInvalidFilters(t *testing.T) {
 			log.Infof("[TEST END] %s", tc.name)
 		})
 	}
+}
+
+
+func TestVdevDistributionStats(t *testing.T) {
+        c := newClient(t)
+        adminToken := getAdminToken(t)
+        c.SetToken(adminToken)
+
+        // Hierarchy Setup as per requirement:
+        // 1 PDU, 1 Rack, 2 HVs, 3 Devices/HV (Total 6), 3 Partitions/Device (Total 18)
+        pduID := "7f5dd612-3fcb-11f1-90ce-efb5cbe5160d"
+        rackID := "86187dae-3fcb-11f1-ab82-a3480faf0666"
+        hvs := []string{"918c9374-3fcb-11f1-98f3-233366157547", "918c9374-3fcb-11f1-98f3-233366157547"}
+        
+        deviceList := []string{}
+        nisdIDCounter := 1
+        
+        log.Infof("Setting up hierarchy for distribution test...")
+        for h, hv := range hvs {
+                for d := 1; d <= 3; d++ {
+                        deviceID := fmt.Sprintf("dev-stats-%d-%d", h+1, d)
+                        deviceList = append(deviceList, deviceID)
+                        for p := 1; p <= 3; p++ {
+                                nisd := cpLib.Nisd{
+                                        PeerPort: 12000 + uint16(nisdIDCounter),
+                                        ID:       uuid.New().String(),
+                                        FailureDomain: []string{
+                                                pduID,
+                                                rackID,
+                                                hv,
+                                                deviceID,
+                                                fmt.Sprintf("%s-pt-%d", deviceID, p),
+                                        },
+                                        TotalSize:     4 * 1024 * 1024 * 1024 * 1024, // 4TB
+                                        AvailableSize: 4 * 1024 * 1024 * 1024 * 1024,
+                                }
+                                _, err := c.PutNisd(&nisd)
+                                require.NoError(t, err)
+                                nisdIDCounter++
+                        }
+                }
+        }
+
+        // Create 1TB Vdev (~125 chunks of 8GB each)
+        // Total allocations with 3 replicas = 375.
+        // 375 / 6 devices = ~62 chunks per device.
+        log.Infof("Creating 1TB Vdev with 3 replicas...")
+        vdevReq := &cpLib.VdevReq{
+                Vdev: &cpLib.VdevCfg{
+                        Size:       3072 * 1024 * 1024 * 1024, // 1TB
+                        NumReplica: 1,
+                },
+        }
+
+        resp, err := c.CreateVdev(vdevReq)
+        require.NoError(t, err)
+        require.True(t, resp.Success)
+        vdevID := resp.ID
+        log.Infof("Created Vdev for distribution test: %s", vdevID)
+
+        // Wait for processing
+        time.Sleep(3 * time.Second)
+
+        // Fetch Vdev with Chunk Mapping
+        vdevs, err := c.GetVdevsWithChunkInfo(&cpLib.GetReq{ID: vdevID})
+	require.NoError(t, err)
+	require.NotEmpty(t, vdevs)
+	for _, vdev := range vdevs {
+		fmt.Printf("Vdev %s: %d chunks\n", vdev.Cfg.ID, vdev.Cfg.NumChunks)
+	}
+	vdev := vdevs[0]
+
+	require.NotNil(t, vdev, "expected vdev with ID %s not found", vdevID)
+        // Calculate Stats per Device
+        deviceStats := make(map[string]int)
+        for _, chunkMap := range vdev.NisdToChkMap {
+                devID := chunkMap.Nisd.FailureDomain[3]
+                deviceStats[devID]+=len(chunkMap.Chunk)
+        }
+
+        fmt.Printf("\n--- Distribution Statistics for Vdev %s ---\n", vdev.Cfg.ID)
+        fmt.Printf("Total chunk-replica mappings: %d\n", vdev.Cfg.NumChunks  * uint32(vdev.Cfg.NumReplica))
+        
+        totalAssignments := 0
+        for _, dev := range deviceList {
+                count := deviceStats[dev]
+                totalAssignments += count
+                fmt.Printf("Device %s: %d chunks\n", dev, count)
+                // With 6 devices and 375 allocations, we expect around 62 each.
+                assert.Greater(t, count, 0, "Device %s should have received at least one chunk", dev)
+        }
+        fmt.Printf("-------------------------------------------\n\n")
+
+	// Clean up
+	c.DeleteVdev(&cpLib.DeleteVdevReq{ID: vdevID})
 }

--- a/controlplane/ctlplanefuncs/client/vdev_entity_filter_test.go
+++ b/controlplane/ctlplanefuncs/client/vdev_entity_filter_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/google/uuid"
 
 	cpLib "github.com/00pauln00/niova-mdsvc/controlplane/ctlplanefuncs/lib"
 )
@@ -386,69 +386,68 @@ func TestCreateVdevWithInvalidFilters(t *testing.T) {
 	}
 }
 
-
 func TestVdevDistributionStats(t *testing.T) {
-        c := newClient(t)
-        adminToken := getAdminToken(t)
-        c.SetToken(adminToken)
+	c := newClient(t)
+	adminToken := getAdminToken(t)
+	c.SetToken(adminToken)
 
-        // Hierarchy Setup as per requirement:
-        // 1 PDU, 1 Rack, 2 HVs, 3 Devices/HV (Total 6), 3 Partitions/Device (Total 18)
-        pduID := "7f5dd612-3fcb-11f1-90ce-efb5cbe5160d"
-        rackID := "86187dae-3fcb-11f1-ab82-a3480faf0666"
-        hvs := []string{"918c9374-3fcb-11f1-98f3-233366157547", "918c9374-3fcb-11f1-98f3-233366157547"}
-        
-        deviceList := []string{}
-        nisdIDCounter := 1
-        
-        log.Infof("Setting up hierarchy for distribution test...")
-        for h, hv := range hvs {
-                for d := 1; d <= 3; d++ {
-                        deviceID := fmt.Sprintf("dev-stats-%d-%d", h+1, d)
-                        deviceList = append(deviceList, deviceID)
-                        for p := 1; p <= 3; p++ {
-                                nisd := cpLib.Nisd{
-                                        PeerPort: 12000 + uint16(nisdIDCounter),
-                                        ID:       uuid.New().String(),
-                                        FailureDomain: []string{
-                                                pduID,
-                                                rackID,
-                                                hv,
-                                                deviceID,
-                                                fmt.Sprintf("%s-pt-%d", deviceID, p),
-                                        },
-                                        TotalSize:     4 * 1024 * 1024 * 1024 * 1024, // 4TB
-                                        AvailableSize: 4 * 1024 * 1024 * 1024 * 1024,
-                                }
-                                _, err := c.PutNisd(&nisd)
-                                require.NoError(t, err)
-                                nisdIDCounter++
-                        }
-                }
-        }
+	// Hierarchy Setup as per requirement:
+	// 1 PDU, 1 Rack, 2 HVs, 3 Devices/HV (Total 6), 3 Partitions/Device (Total 18)
+	pduID := "7f5dd612-3fcb-11f1-90ce-efb5cbe5160d"
+	rackID := "86187dae-3fcb-11f1-ab82-a3480faf0666"
+	hvs := []string{"918c9374-3fcb-11f1-98f3-233366157547", "918c9374-3fcb-11f1-98f3-233366157547"}
 
-        // Create 1TB Vdev (~125 chunks of 8GB each)
-        // Total allocations with 3 replicas = 375.
-        // 375 / 6 devices = ~62 chunks per device.
-        log.Infof("Creating 1TB Vdev with 3 replicas...")
-        vdevReq := &cpLib.VdevReq{
-                Vdev: &cpLib.VdevCfg{
-                        Size:       3072 * 1024 * 1024 * 1024, // 1TB
-                        NumReplica: 1,
-                },
-        }
+	deviceList := []string{}
+	nisdIDCounter := 1
 
-        resp, err := c.CreateVdev(vdevReq)
-        require.NoError(t, err)
-        require.True(t, resp.Success)
-        vdevID := resp.ID
-        log.Infof("Created Vdev for distribution test: %s", vdevID)
+	log.Infof("Setting up hierarchy for distribution test...")
+	for h, hv := range hvs {
+		for d := 1; d <= 3; d++ {
+			deviceID := fmt.Sprintf("dev-stats-%d-%d", h+1, d)
+			deviceList = append(deviceList, deviceID)
+			for p := 1; p <= 3; p++ {
+				nisd := cpLib.Nisd{
+					PeerPort: 12000 + uint16(nisdIDCounter),
+					ID:       uuid.New().String(),
+					FailureDomain: []string{
+						pduID,
+						rackID,
+						hv,
+						deviceID,
+						fmt.Sprintf("%s-pt-%d", deviceID, p),
+					},
+					TotalSize:     4 * 1024 * 1024 * 1024 * 1024, // 4TB
+					AvailableSize: 4 * 1024 * 1024 * 1024 * 1024,
+				}
+				_, err := c.PutNisd(&nisd)
+				require.NoError(t, err)
+				nisdIDCounter++
+			}
+		}
+	}
 
-        // Wait for processing
-        time.Sleep(3 * time.Second)
+	// Create 1TB Vdev (~125 chunks of 8GB each)
+	// Total allocations with 3 replicas = 375.
+	// 375 / 6 devices = ~62 chunks per device.
+	log.Infof("Creating 1TB Vdev with 3 replicas...")
+	vdevReq := &cpLib.VdevReq{
+		Vdev: &cpLib.VdevCfg{
+			Size:       3072 * 1024 * 1024 * 1024, // 1TB
+			NumReplica: 1,
+		},
+	}
 
-        // Fetch Vdev with Chunk Mapping
-        vdevs, err := c.GetVdevsWithChunkInfo(&cpLib.GetReq{ID: vdevID})
+	resp, err := c.CreateVdev(vdevReq)
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+	vdevID := resp.ID
+	log.Infof("Created Vdev for distribution test: %s", vdevID)
+
+	// Wait for processing
+	time.Sleep(3 * time.Second)
+
+	// Fetch Vdev with Chunk Mapping
+	vdevs, err := c.GetVdevsWithChunkInfo(&cpLib.GetReq{ID: vdevID})
 	require.NoError(t, err)
 	require.NotEmpty(t, vdevs)
 	for _, vdev := range vdevs {
@@ -457,26 +456,87 @@ func TestVdevDistributionStats(t *testing.T) {
 	vdev := vdevs[0]
 
 	require.NotNil(t, vdev, "expected vdev with ID %s not found", vdevID)
-        // Calculate Stats per Device
-        deviceStats := make(map[string]int)
-        for _, chunkMap := range vdev.NisdToChkMap {
-                devID := chunkMap.Nisd.FailureDomain[3]
-                deviceStats[devID]+=len(chunkMap.Chunk)
-        }
+	// Calculate Stats per Device
+	deviceStats := make(map[string]int)
+	for _, chunkMap := range vdev.NisdToChkMap {
+		devID := chunkMap.Nisd.FailureDomain[3]
+		deviceStats[devID] += len(chunkMap.Chunk)
+	}
 
-        fmt.Printf("\n--- Distribution Statistics for Vdev %s ---\n", vdev.Cfg.ID)
-        fmt.Printf("Total chunk-replica mappings: %d\n", vdev.Cfg.NumChunks  * uint32(vdev.Cfg.NumReplica))
-        
-        totalAssignments := 0
-        for _, dev := range deviceList {
-                count := deviceStats[dev]
-                totalAssignments += count
-                fmt.Printf("Device %s: %d chunks\n", dev, count)
-                // With 6 devices and 375 allocations, we expect around 62 each.
-                assert.Greater(t, count, 0, "Device %s should have received at least one chunk", dev)
-        }
-        fmt.Printf("-------------------------------------------\n\n")
+	fmt.Printf("\n--- Distribution Statistics for Vdev %s ---\n", vdev.Cfg.ID)
+	fmt.Printf("Total chunk-replica mappings: %d\n", vdev.Cfg.NumChunks*uint32(vdev.Cfg.NumReplica))
+
+	totalAssignments := 0
+	for _, dev := range deviceList {
+		count := deviceStats[dev]
+		totalAssignments += count
+		fmt.Printf("Device %s: %d chunks\n", dev, count)
+		// With 6 devices and 375 allocations, we expect around 62 each.
+		assert.Greater(t, count, 0, "Device %s should have received at least one chunk", dev)
+	}
+	fmt.Printf("-------------------------------------------\n\n")
 
 	// Clean up
 	c.DeleteVdev(&cpLib.DeleteVdevReq{ID: vdevID})
+}
+
+func TestPrintDeviceDistribution(t *testing.T) {
+	c := newClient(t)
+	adminToken := getAdminToken(t)
+	c.SetToken(adminToken)
+
+	// Step 1: Fetch all Vdev Configs
+	cfgs, err := c.GetVdevCfgs(&cpLib.GetReq{
+		GetAll: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, cfgs)
+
+	deviceStats := make(map[string]int)
+
+	totalExpectedMappings := 0
+	totalAssignments := 0
+
+	// Step 2: Iterate each VdevID
+	for _, cfg := range cfgs {
+		vdevID := cfg.ID
+
+		// Step 3: Fetch chunk info for this specific vdev
+		vdevs, err := c.GetVdevsWithChunkInfo(&cpLib.GetReq{
+			ID: vdevID,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, vdevs)
+
+		vdev := vdevs[0]
+		require.NotNil(t, vdev)
+
+		fmt.Printf("Vdev %s: %d chunks\n", vdev.Cfg.ID, vdev.Cfg.NumChunks)
+
+		totalExpectedMappings += int(vdev.Cfg.NumChunks * uint32(vdev.Cfg.NumReplica))
+
+		// Step 4: Count chunks per device
+		for _, chunkMap := range vdev.NisdToChkMap {
+			if len(chunkMap.Nisd.FailureDomain) <= 3 {
+				continue // avoid panic on malformed data
+			}
+
+			devID := chunkMap.Nisd.FailureDomain[3]
+			count := len(chunkMap.Chunk)
+
+			deviceStats[devID] += count
+			totalAssignments += count
+		}
+	}
+
+	// Final aggregated stats
+	fmt.Printf("\n--- Aggregated Device Distribution Across ALL Vdevs ---\n")
+	fmt.Printf("Total expected mappings: %d\n", totalExpectedMappings)
+	fmt.Printf("Total actual assignments: %d\n", totalAssignments)
+
+	for devID, count := range deviceStats {
+		fmt.Printf("Device %s: %d chunks\n", devID, count)
+	}
+
+	fmt.Printf("------------------------------------------------------\n\n")
 }

--- a/controlplane/ctlplanefuncs/server/hierarchy.go
+++ b/controlplane/ctlplanefuncs/server/hierarchy.go
@@ -153,13 +153,14 @@ func (hr *Hierarchy) LookupNAddNisd(nisd *ctlplfl.Nisd, nisdMap *btree.Map[strin
 
 // Pick a  NISD using the hash from a specific failure domain.
 func (hr *Hierarchy) PickNISD(ent *Entities, picked map[string]struct{},
-	nisdMap *btree.Map[string, *ctlplfl.NisdVdevAlloc]) (*cpLib.NisdVdevAlloc, error) {
+	nisdMap *btree.Map[string, *ctlplfl.NisdVdevAlloc], pickedDevices map[string]int) (*cpLib.NisdVdevAlloc, error) {
 
 	// select NISD inside entity
 	nisdCnt := ent.Nisds.Len()
 
-	// nisd with highest available capacity
+	// nisd with highest available capacity among least-allocated devices
 	var OptimalNisd *cpLib.NisdVdevAlloc
+	minAllocCount := -1
 
 	for i := 0; i < nisdCnt; i++ {
 		nisd, ok := ent.Nisds.GetAt(i)
@@ -180,9 +181,17 @@ func (hr *Hierarchy) PickNISD(ent *Entities, picked map[string]struct{},
 			continue
 		}
 
-		// if the current nisd's available space is > then optimal nisd's available space, update the OptimalNisd value
-		if OptimalNisd == nil || nAlloc.AvailableSize > OptimalNisd.AvailableSize {
+		deviceID := nAlloc.Ptr.FailureDomain[cpLib.DEVICE_IDX]
+		allocCount := pickedDevices[deviceID]
+
+		// Select based on minimum allocation count, then maximum available size
+		if minAllocCount == -1 || allocCount < minAllocCount {
+			minAllocCount = allocCount
 			OptimalNisd = nAlloc
+		} else if allocCount == minAllocCount {
+			if OptimalNisd == nil || nAlloc.AvailableSize > OptimalNisd.AvailableSize {
+				OptimalNisd = nAlloc
+			}
 		}
 	}
 
@@ -193,6 +202,9 @@ func (hr *Hierarchy) PickNISD(ent *Entities, picked map[string]struct{},
 	// commit selection
 	OptimalNisd.AvailableSize -= ctlplfl.CHUNK_SIZE
 	picked[OptimalNisd.Ptr.ID] = struct{}{}
+
+	// increment allocation count for this device
+	pickedDevices[OptimalNisd.Ptr.FailureDomain[cpLib.DEVICE_IDX]]++
 
 	return OptimalNisd, nil
 }

--- a/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
+++ b/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
@@ -658,7 +658,8 @@ func WPCreateVdev(args ...interface{}) (interface{}, error) {
 
 func allocateNisdPerChunk(req *ctlplfl.VdevReq, fd int, chunk string,
 	commitChgs *[]funclib.CommitChg,
-	nisdMap *btree.Map[string, *ctlplfl.NisdVdevAlloc]) error {
+	nisdMap *btree.Map[string, *ctlplfl.NisdVdevAlloc],
+	pickedDevices map[string]int) error {
 
 	if fd < 0 || fd >= ctlplfl.FD_MAX {
 		return fmt.Errorf("invalid failure domain: %d", fd)
@@ -681,7 +682,7 @@ func allocateNisdPerChunk(req *ctlplfl.VdevReq, fd int, chunk string,
 		}
 
 		for r := 0; r < int(req.Vdev.NumReplica); r++ {
-			nisd, err := HR.PickNISD(en, pickedNISD, nisdMap)
+			nisd, err := HR.PickNISD(en, pickedNISD, nisdMap, pickedDevices)
 			if err != nil {
 				log.Error("PickNISD():failed to pick NISD: ", err)
 				return err
@@ -725,7 +726,7 @@ func allocateNisdPerChunk(req *ctlplfl.VdevReq, fd int, chunk string,
 				continue
 			}
 
-			nisd, lastErr = HR.PickNISD(ent, pickedNISD, nisdMap)
+			nisd, lastErr = HR.PickNISD(ent, pickedNISD, nisdMap, pickedDevices)
 			if lastErr == nil {
 				picked = curIdx
 				break
@@ -748,9 +749,10 @@ func allocateNisdPerChunk(req *ctlplfl.VdevReq, fd int, chunk string,
 
 func allocateNisdPerVdev(req *ctlplfl.VdevReq, fd int, nisdMap *btree.Map[string, *ctlplfl.NisdVdevAlloc]) ([]funclib.CommitChg, error) {
 	commitCh := make([]funclib.CommitChg, 0)
+	pickedDevices := make(map[string]int)
 	for i := 0; i < int(req.Vdev.NumChunks); i++ {
 		log.Debugf("allocating nisd for chunk: %d, from fd: %d ", i, fd)
-		err := allocateNisdPerChunk(req, fd, strconv.Itoa(i), &commitCh, nisdMap)
+		err := allocateNisdPerChunk(req, fd, strconv.Itoa(i), &commitCh, nisdMap, pickedDevices)
 		if err != nil {
 			err = fmt.Errorf("failed to allocate nisd from fd: %d, %v", fd, err)
 			log.Error(err)


### PR DESCRIPTION
- vdev allocation algorithm, was not distributing chunks on all devices evenly, because of which we could observe some performance uneven workload on the devices.
- made changes to add device level filtering to algorithm so it can distribute the chunks on devices evenly.