### PR TITLE
fix: use random offset for better space distribution

### DIFF
--- a/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
+++ b/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
@@ -22,6 +22,7 @@ import (
 	PumiceDBServer "github.com/00pauln00/niova-pumicedb/go/pkg/pumiceserver"
 	storageiface "github.com/00pauln00/niova-pumicedb/go/pkg/utils/storage/interface"
 )
+import "math/rand"
 
 var colmfamily string
 
@@ -1831,9 +1832,13 @@ func WPPFSCfg(args ...interface{}) (interface{}, error) {
 		Success: true,
 	}
 
+	rand.Seed(time.Now().UnixNano())
+
+	offset := rand.Intn(HR.GetEntityCnt(ctlplfl.DEVICE_IDX)) + 1
+
 	commitChgs := []funclib.CommitChg{
 		{Key: []byte(fmt.Sprintf("%s/%s/nm", pfsKey, pfs.ID)), Value: []byte(pfs.Name)},
-		{Key: []byte(fmt.Sprintf("%s/%s/offset", pfsKey, pfs.ID)), Value: []byte("0")},
+		{Key: []byte(fmt.Sprintf("%s/%s/offset", pfsKey, pfs.ID)), Value: []byte(fmt.Sprintf("%d", offset))},
 	}
 
 	funcIntrm := funclib.FuncIntrm{

--- a/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
+++ b/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
@@ -3,6 +3,7 @@ package srvctlplanefuncs
 import (
 	"C"
 	"fmt"
+	"math/rand"
 	"path"
 	"strconv"
 	"strings"
@@ -22,7 +23,6 @@ import (
 	PumiceDBServer "github.com/00pauln00/niova-pumicedb/go/pkg/pumiceserver"
 	storageiface "github.com/00pauln00/niova-pumicedb/go/pkg/utils/storage/interface"
 )
-import "math/rand"
 
 var colmfamily string
 
@@ -1831,8 +1831,6 @@ func WPPFSCfg(args ...interface{}) (interface{}, error) {
 		Name:    pfs.Name,
 		Success: true,
 	}
-
-	rand.Seed(time.Now().UnixNano())
 
 	offset := rand.Intn(HR.GetEntityCnt(ctlplfl.DEVICE_IDX)) + 1
 


### PR DESCRIPTION
	- previosly all the vdevs where being assigned from device 0 as the default offset value was 0, resulting in space imbalance.
	- To fix the issue, made changes to use randomized offset value