### PR TITLE
fix: PFS reverse-mapping key not removed on vdev deletion

### DIFF
--- a/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
+++ b/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
@@ -1820,7 +1820,7 @@ func APDeleteVdev(args ...interface{}) (interface{}, error) {
 	commitChgs := make([]funclib.CommitChg, 0)
 	deleteChgs := make([]funclib.CommitChg, 0)
 	nisdRefundMap := make(map[string]*ctlplfl.Nisd)
-	var vdevName string
+	var vdevName, vdevPFSID string
 
 	log.Infof("APDeleteVdev: deleting vdev %q", req.ID)
 	// Validate Vdev exists
@@ -1845,6 +1845,10 @@ func APDeleteVdev(args ...interface{}) (interface{}, error) {
 			// Capture vdev name so we can remove the reverse-index entry.
 			if strings.HasSuffix(k, "/"+cfgkey+"/"+NAME) {
 				vdevName = string(v)
+			}
+			// Capture PFSID so we can remove the pfs-vdev reverse-index entry.
+			if strings.HasSuffix(k, "/"+cfgkey+"/"+pfsKey) {
+				vdevPFSID = string(v)
 			}
 			// Delete
 			deleteChgs = append(deleteChgs, funclib.CommitChg{
@@ -1914,6 +1918,14 @@ func APDeleteVdev(args ...interface{}) (interface{}, error) {
 	if vdevName != "" {
 		deleteChgs = append(deleteChgs, funclib.CommitChg{
 			Key:   []byte(fmt.Sprintf("%s/%s", vnameKey, vdevName)),
+			Value: nil,
+		})
+	}
+
+	// Remove pfs-vdev reverse-index entry.
+	if vdevPFSID != "" {
+		deleteChgs = append(deleteChgs, funclib.CommitChg{
+			Key:   []byte(fmt.Sprintf("%s/%s/v/%s", pfsKey, vdevPFSID, req.ID)),
 			Value: nil,
 		})
 	}

--- a/controlplane/ctlplanefuncs/server/srvctlplanefuncs_test.go
+++ b/controlplane/ctlplanefuncs/server/srvctlplanefuncs_test.go
@@ -726,6 +726,29 @@ func TestAPDeleteVdev(t *testing.T) {
 			},
 		},
 		{
+			name: "SuccessfulDelete_WithPFS",
+			setupData: func(ds storageiface.DataStore) {
+				testPFSUUID := "a1b2c3d4-0000-0000-0000-000000000001"
+				setupBasicVdevAndNisd(ds, testVdevUUID, testNisdUUID)
+				// pfs cfg key inside vdev namespace
+				ds.Write(fmt.Sprintf("v/%s/cfg/pfs", testVdevUUID), testPFSUUID, "")
+				// pfs-vdev reverse mapping
+				ds.Write(fmt.Sprintf("pfs/%s/v/%s", testPFSUUID, testVdevUUID), "1", "")
+			},
+			setupHR:     func() { setupHRWithNisd(testNisdUUID, 1073741824) },
+			vdevID:      testVdevUUID,
+			expectError: false,
+			verify: func(t *testing.T, ds storageiface.DataStore) {
+				testPFSUUID := "a1b2c3d4-0000-0000-0000-000000000001"
+				if _, err := ds.Read(fmt.Sprintf("v/%s/cfg/pfs", testVdevUUID), ""); err == nil {
+					t.Error("vdev cfg/pfs key should be deleted")
+				}
+				if _, err := ds.Read(fmt.Sprintf("pfs/%s/v/%s", testPFSUUID, testVdevUUID), ""); err == nil {
+					t.Error("pfs-vdev reverse mapping key should be deleted")
+				}
+			},
+		},
+		{
 			name:          "Error_MissingToken",
 			setupData:     func(ds storageiface.DataStore) { setupBasicVdevAndNisd(ds, testVdevUUID, testNisdUUID) },
 			setupHR:       func() { setupHRWithNisd(testNisdUUID, 1073741824) },


### PR DESCRIPTION
Fix for issue: https://github.com/niova/niova-mdsvc/issues/107