### PR TITLE
feat: Wrap niova-block to CP Request in CPReq Format

### DIFF
--- a/controlplane/ctlplanefuncs/client/clictlplanefuncs.go
+++ b/controlplane/ctlplanefuncs/client/clictlplanefuncs.go
@@ -279,7 +279,7 @@ func (ccf *CliCFuncs) GetNisds(req ctlplfl.GetReq) ([]ctlplfl.Nisd, error) {
 func (ccf *CliCFuncs) GetNisd(req ctlplfl.GetReq) (*ctlplfl.Nisd, error) {
 	cpReq := &ctlplfl.CPReq{
 		Token:   ccf.token,
-		Payload: req,
+		Payload: ctlplfl.GetReqEnvelope{Req: req},
 	}
 	ncfg := &ctlplfl.Nisd{}
 	cpResp, err := ccf.get(cpReq, ctlplfl.GET_NISD, ncfg)
@@ -564,7 +564,7 @@ func (ccf *CliCFuncs) GetVdevCfg(req *ctlplfl.GetReq) (ctlplfl.VdevCfg, error) {
 	vdev := ctlplfl.VdevCfg{}
 	cpReq := &ctlplfl.CPReq{
 		Token:   ccf.token,
-		Payload: req,
+		Payload: ctlplfl.GetReqEnvelope{Req: *req},
 	}
 	cpResp, err := ccf.get(cpReq, ctlplfl.GET_VDEV_INFO, &vdev)
 	if err != nil {
@@ -626,7 +626,7 @@ func (ccf *CliCFuncs) GetChunkNisd(req *ctlplfl.GetReq) (ctlplfl.ChunkNisd, erro
 	log.Info("fetching chunk Info for:", req.ID)
 	cpReq := &ctlplfl.CPReq{
 		Token:   ccf.token,
-		Payload: req,
+		Payload: ctlplfl.GetReqEnvelope{Req: *req},
 	}
 	cpResp, err := ccf.get(cpReq, ctlplfl.GET_CHUNK_NISD, &cn)
 	if err != nil {

--- a/controlplane/ctlplanefuncs/lib/libctlplanefuncs.go
+++ b/controlplane/ctlplanefuncs/lib/libctlplanefuncs.go
@@ -363,6 +363,10 @@ type GetReq struct {
 	Fields []string
 }
 
+type GetReqEnvelope struct {
+	Req GetReq `xml:"GetReq"`
+}
+
 type ResourceType string
 
 const (

--- a/controlplane/proxy/translator.go
+++ b/controlplane/proxy/translator.go
@@ -25,8 +25,10 @@ func GetEncodingType(r *http.Request) pmLib.Format {
 
 func GetReqStruct(name string) any {
 	switch name {
-	case cpLib.GET_RACK, cpLib.GET_NISD, cpLib.GET_DEVICE, cpLib.GET_PDU, cpLib.GET_HYPERVISOR, cpLib.GET_PARTITION, cpLib.GET_VDEV, cpLib.GET_CHUNK_NISD, userlib.LoginAPI, cpLib.GET_VDEV_CHUNK_INFO, cpLib.GET_VDEV_INFO, cpLib.GET_PFS, cpLib.GET_NISD_AVAILABLE_SIZES:
+	case cpLib.GET_RACK, cpLib.GET_DEVICE, cpLib.GET_PDU, cpLib.GET_HYPERVISOR, cpLib.GET_PARTITION, cpLib.GET_VDEV, cpLib.GET_VDEV_CHUNK_INFO, cpLib.GET_PFS, cpLib.GET_NISD_AVAILABLE_SIZES:
 		return &cpLib.GetReq{}
+	case cpLib.GET_NISD, cpLib.GET_CHUNK_NISD, userlib.LoginAPI, cpLib.GET_VDEV_INFO:
+		return &cpLib.GetReqEnvelope{}
 	case cpLib.GET_ALL_RESOURCES:
 		return &cpLib.GetResourceReq{}
 	case cpLib.PUT_RACK:
@@ -146,6 +148,8 @@ func derefPtr(v any) any {
 	switch p := v.(type) {
 	case *cpLib.GetReq:
 		return *p
+	case *cpLib.GetReqEnvelope:
+		return p.Req
 	case *cpLib.Rack:
 		return *p
 	case *cpLib.Device:

--- a/controlplane/user/client/client.go
+++ b/controlplane/user/client/client.go
@@ -263,8 +263,10 @@ func (c *Client) UpdateAdminSecretKey(userID, newSecretKey, userToken string) (*
 
 // Login authenticates the user with username and secret key, returns JWT token.
 func (c *Client) Login(username, secretKey string) (*userlib.LoginResp, error) {
-	req := &cpLib.GetReq{
-		ID: fmt.Sprintf("%s:%s", username, secretKey),
+	req := &cpLib.GetReqEnvelope{
+		Req: cpLib.GetReq{
+			ID: fmt.Sprintf("%s:%s", username, secretKey),
+		},
 	}
 
 	resp := &userlib.LoginResp{}


### PR DESCRIPTION
- Process all request from `niova-block` as CPReq wraper

Related to: https://github.com/niova/niova-mdsvc/issues/113