### PR TITLE
Allow hyphens in vdev name validation

### DIFF
--- a/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
+++ b/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
@@ -637,7 +637,7 @@ func isAlphanumeric(s string) bool {
 		return false
 	}
 	for _, c := range s {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c== '-')) {
 			return false
 		}
 	}

--- a/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
+++ b/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
@@ -637,7 +637,7 @@ func isAlphanumeric(s string) bool {
 		return false
 	}
 	for _, c := range s {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c== '-')) {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c == '-') || (c == '_')) {
 			return false
 		}
 	}

--- a/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
+++ b/controlplane/ctlplanefuncs/server/srvctlplanefuncs.go
@@ -668,7 +668,7 @@ func WPCreateVdev(args ...interface{}) (interface{}, error) {
 		return ctlplfl.WPAuthError(err)
 	}
 	if len(req.Vdev.Name) > 0 && !isAlphanumeric(req.Vdev.Name) {
-		return ctlplfl.WPFuncError(fmt.Errorf("vdev name %q is invalid: must be non-empty and contain only letters and digits", req.Vdev.Name))
+		return ctlplfl.WPFuncError(fmt.Errorf("vdev name %q is invalid: must be non-empty and contain only letters, digits and hyphen(-)", req.Vdev.Name))
 	}
 
 	err = req.Vdev.Init()

--- a/controlplane/niova-ctl/main.go
+++ b/controlplane/niova-ctl/main.go
@@ -9155,7 +9155,7 @@ func isAlphanumericStr(s string) bool {
 		return false
 	}
 	for _, c := range s {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c == '-')) {
 			return false
 		}
 	}

--- a/controlplane/niova-ctl/main.go
+++ b/controlplane/niova-ctl/main.go
@@ -9155,7 +9155,7 @@ func isAlphanumericStr(s string) bool {
 		return false
 	}
 	for _, c := range s {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c == '-')) {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || (c == '-') || (c == '_')) {
 			return false
 		}
 	}

--- a/controlplane/niova-ctl/main.go
+++ b/controlplane/niova-ctl/main.go
@@ -8457,7 +8457,7 @@ func (m model) updateVdevForm(msg tea.Msg) (model, tea.Cmd) {
 				return m, nil
 			}
 			if !isAlphanumericStr(nameStr) {
-				m.message = "Vdev name must contain only letters and digits"
+				m.message = "Vdev name must contain only letters, digits and hyphen(-)"
 				return m, nil
 			}
 


### PR DESCRIPTION
- Modified `isAlphanumeric()` to accept the `-` character.
- Updated the validation error message to indicate that hyphens are allowed.