### PR TITLE
Restore redundancy fields in CreateVdev request

### DIFF
--- a/controlplane/ctlplanefuncs/client/clictlplanefuncs.go
+++ b/controlplane/ctlplanefuncs/client/clictlplanefuncs.go
@@ -496,9 +496,11 @@ func (ccf *CliCFuncs) CreateVdev(vdev *ctlplfl.VdevReq) (*ctlplfl.ResponseXML, e
 	// optional failure-domain filter, and an optional PFS link. Name is a
 	// niova-only extension the proxy forwards for name-based lookup.
 	reqBody := restapi.CreateVdevRequest{
-		SizeBytes:   vdev.Vdev.Size,
-		NumReplicas: int(vdev.Vdev.DataBlkCnt),
-		Name:        vdev.Vdev.Name,
+		SizeBytes:    vdev.Vdev.Size,
+		DataBlkCnt:   int(vdev.Vdev.DataBlkCnt),
+		ParityBlkCnt: int(vdev.Vdev.ParityBlkCnt),
+		Redundancy:   int(vdev.Vdev.Redundancy),
+		Name:         vdev.Vdev.Name,
 	}
 	// Forward failure-domain scoping. FD_ANY means no scoping, so omit it.
 	if vdev.Filter.Type != ctlplfl.FD_ANY {

--- a/controlplane/proxy/restapi_writes.go
+++ b/controlplane/proxy/restapi_writes.go
@@ -33,7 +33,7 @@ func (handler *proxyHandler) handleCreateVdev(w http.ResponseWriter, r *http.Req
 		restapi.WriteMethodError(w, restapi.StatusInvalidRequest, "size_bytes must be >= 1")
 		return
 	}
-	if req.NumReplicas < 1 || req.NumReplicas > maxVdevReplicas {
+	if req.DataBlkCnt < 1 || req.DataBlkCnt > maxVdevReplicas {
 		restapi.WriteMethodError(w, restapi.StatusInvalidRequest, "num_replicas must be between 1 and %d", maxVdevReplicas)
 		return
 	}
@@ -63,7 +63,7 @@ func (handler *proxyHandler) handleCreateVdev(w http.ResponseWriter, r *http.Req
 	vdevCfg := &cpLib.VdevConfig{
 		Size:       req.SizeBytes,
 		Redundancy: cpLib.RMReplica,
-		DataBlkCnt: uint8(req.NumReplicas),
+		DataBlkCnt: uint8(req.DataBlkCnt),
 		Name:       strings.TrimSpace(req.Name),
 	}
 	// Optional PFS link, supplied as either the PFS id (UUID) or its name. The

--- a/controlplane/restapi/types.go
+++ b/controlplane/restapi/types.go
@@ -72,8 +72,12 @@ type NISDNode struct {
 // ---- /create_vdev ----
 
 type CreateVdevRequest struct {
-	SizeBytes   int64 `json:"size_bytes"`
-	NumReplicas int   `json:"num_replicas"`
+	SizeBytes    int64 `json:"size_bytes"`
+	DataBlkCnt   int   `json:"data_blk_cnt"`             // data blocks per chunk (replica count for replication)
+	ParityBlkCnt int   `json:"parity_blk_cnt,omitempty"` // parity blocks per chunk (0 for replication)
+	// Redundancy selects the chunk redundancy scheme: 0=REPLICATION, 1=EC_32K,
+	// 2=EC_64K, 3=EC_128K. See models.Redundancy for the full mapping.
+	Redundancy int `json:"redundancy,omitempty"`
 	// FailureDomain scopes NISD allocation to a failure-domain level
 	// ("pdu"|"rack"|"hv"|"device"|"partition"); empty/"any" auto-picks.
 	FailureDomain string `json:"failure_domain,omitempty"`


### PR DESCRIPTION
Restore the data block, parity block, and redundancy fields in the `CreateVdev` request .